### PR TITLE
Replacement/generalization of "Scale down kubernetes applications when not in use"

### DIFF
--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -5,7 +5,8 @@ published_date: TBD
 category: [PATTERN_TAG_CATEGORY]
 description: [PATTERN_DESCRIPTION_METADATA]
 tags: 
- - [PATTERN_TAGS]
+ - cloud
+ - size:small
 ---
 
 # [PATTERN_TITLE_ACTION_ON_RESOURCE]

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -5,8 +5,7 @@ published_date: TBD
 category: [PATTERN_TAG_CATEGORY]
 description: [PATTERN_DESCRIPTION_METADATA]
 tags: 
- - cloud
- - size:small
+ - [PATTERN_TAGS]
 ---
 
 # [PATTERN_TITLE_ACTION_ON_RESOURCE]

--- a/docs/catalog/cloud/scale-down-unused-applications.md
+++ b/docs/catalog/cloud/scale-down-unused-applications.md
@@ -1,0 +1,43 @@
+---
+version: 1.0
+submitted_by: yelghali, markus-ntt-seidl
+published_date: TBD
+category: cloud
+description: [PATTERN_DESCRIPTION_METADATA]
+tags: 
+ - cloud
+ - size:small
+---
+
+# Scale down applications when not in use
+
+## Description
+
+Applications tend to consume CPU even when they are not actively used. This includes background timers, garbage collection, health checks among others. Even when the application is shut down, the underlying Hardware consumes idle power.
+This hold also true for Development and Test applications and hardware in out-of-office hours.
+
+
+## Solution
+
+Scale down applications and hardware that are not in use on a schedule. Cloud vendors and software solutions (ex. Kubernetes) provide various ways on how to achieve this efficiently.
+
+## SCI Impact
+
+`SCI = (E * I) + M per R`  
+[Software Carbon Intensity Spec](https://grnsft.org/sci)
+
+Regarding the SCI equation. Scaling down the pods to zero will impact:
+
+- `E`: Reduces energy consumption in hours when the application and hardware can be shut down or switched off.
+
+## Assumptions
+
+- Assumes that the Application has predictable traffic or usage patterns, which need to be known in advance.
+
+## Considerations
+
+- Consider moving to a Serverless Architecture
+
+## References
+
+- [Azure Well-Architected Framework Sustainability Pillar](https://learn.microsoft.com/en-us/azure/architecture/framework/sustainability/sustainability-application-design)


### PR DESCRIPTION
The pattern "Turn off workloads outside of business hours" from #108  and https://patterns.greensoftware.foundation/catalog/cloud/scale-down-kubernetes-workloads/ are very similar.
Additionally the pattern on the web page is very specific and includes unfinished text (ex: "=> thereby").

This pattern is a replacement of "Scale down kubernetes applications when not in use"