### PR TITLE
for typo #240 Fix grammatical error in guide/index.md

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -106,7 +106,7 @@ TODO
 
 ## How granular should my pattern be?
 
-We prefer smaller atomic patterns larger patterns. A helpful way to approach a pattern is defining a specific `Action` to take on a specific `Resource`. For example, `Write efficient code` would be rejected as too generic since there is no specific action to take on a specific resource. Whereas `Cache Static Data` provides a specific action of Caching to a specific resource of Static Data.  
+We prefer smaller atomic patterns to larger patterns. A helpful way to approach a pattern is defining a specific `Action` to take on a specific `Resource`. For example, `Write efficient code` would be rejected as too generic since there is no specific action to take on a specific resource. Whereas `Cache Static Data` provides a specific action of Caching to a specific resource of Static Data.  
 
 ### Least number of solutions per pattern
 


### PR DESCRIPTION
Fix for https://github.com/Green-Software-Foundation/patterns/issues/240

Small grammatical error in guide/index.md. Used `to` rather than `more than` in my issue raised as it is the most correct using this website for assurance: https://www.englishalex.com/post/how-to-use-prefer-in-english-prefer-to-vs-prefer-than-a-common-mistake
