### PR TITLE
Add ai-ml-engineer persona to carbon-aware-ai-scheduling pattern

### DIFF
--- a/docs/operations/carbon-aware-ai-scheduling.md
+++ b/docs/operations/carbon-aware-ai-scheduling.md
@@ -12,8 +12,9 @@ tags:
  - persona:devops-engineer
  - persona:infrastructure-engineer
  - persona:solution-architect
+ - persona:ai-ml-engineer
  - size:large
-personas: DevOps Engineer, Infrastructure Engineer, Solution Architect
+personas: DevOps Engineer, Infrastructure Engineer, Solution Architect, AI/ML Engineer
 description: Reduce the carbon impact of AI workloads by running them in cloud regions with lower grid carbon intensity and scheduling deferrable jobs during periods of high renewable energy availability.
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to #407. All 9 new AI patterns from that PR were tagged with the `ai-ml-engineer` persona except `docs/operations/carbon-aware-ai-scheduling.md`, which only carried `devops-engineer`, `infrastructure-engineer`, and `solution-architect`. This adds the missing `persona:ai-ml-engineer` tag (and `AI/ML Engineer` to the `personas` field) so the pattern is consistent with the rest of the set.

## Changes
- `docs/operations/carbon-aware-ai-scheduling.md`: add `persona:ai-ml-engineer` tag and `AI/ML Engineer` to `personas`

## Test plan
- [x] Verified YAML front matter is still valid
- [x] Confirmed the other 8 patterns from #407 already carry this persona tag for consistency


---
_Generated by [Claude Code](https://claude.ai/code/session_01RLUKPDEBYCcvaf5tknAwzB)_